### PR TITLE
dockerのredis追加に伴い、docker-composeを設定

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,7 @@ aws.json
 GOSICK
 
 slack.json
+
+# データ永続化
+/docker/construct_redis/data/*
+!.gitkeep

--- a/README-ja.md
+++ b/README-ja.md
@@ -27,6 +27,20 @@ aws.json
 $ docker build -t gosick ./
 $ sh ./scripts/docker_run
 
+---- Dockerを起動しシェル起動（docker-composeの場合）
+ビルド&起動
+$ docker-compose up --build -d
+
+各コンテナログイン
+$ sh ./scripts/docker_app_run
+$ sh ./scripts/docker_redis_run
+
+停止
+$ docker-compose stop
+
+停止およびコンテナ削除したい場合はこちら
+$ docker-compose down
+
 ---- Build
 プロジェクトルートディレクトリにて実行
 # sh ./scripts/build.sh

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,20 @@
+version: '3'
+services:
+  app:
+    build:
+      context: ./                                   # Dockerfileの実行場所指定
+      dockerfile: ./docker/construct_app/Dockerfile # Dockerfile指定
+    image: gosick-app                               # イメージ名
+    container_name: gosick-app                      # コンテナ名
+    tty: true
+    volumes:                                        # プロジェクトルートディレクトリをworkdir(/gosick)にマウント
+      - ./:/gosick
+
+  redis:
+    build:
+      context: ./docker/construct_redis    # Dockerfile保存場所
+    image: gosick-redis                    # イメージ名
+    container_name: gosick-redis           # コンテナ名
+    command: redis-server --appendonly yes # データをファイルに保存
+    volumes:                               # 永続化
+       - ./docker/construct_redis/data:/data

--- a/docker/construct_app/Dockerfile
+++ b/docker/construct_app/Dockerfile
@@ -8,15 +8,10 @@ COPY . .
 RUN apk add --no-cache git gcc musl-dev
 RUN \
 	mkdir -p /aws && \
-	apk -Uuv add groff less python py-pip && \
+	apk -Uuv add groff less python py-pip redis && \
 	pip install awscli && \
 	apk --purge -v del py-pip && \
 	rm /var/cache/apk/*
 
 
 RUN go get
-
-
-
-
-

--- a/docker/construct_redis/Dockerfile
+++ b/docker/construct_redis/Dockerfile
@@ -1,0 +1,1 @@
+FROM redis:5.0.2-alpine

--- a/scripts/docker_app_run
+++ b/scripts/docker_app_run
@@ -1,0 +1,1 @@
+docker exec -it gosick-app /bin/sh

--- a/scripts/docker_redis_run
+++ b/scripts/docker_redis_run
@@ -1,0 +1,1 @@
+docker exec -it gosick-redis /bin/sh


### PR DESCRIPTION
コンテナ名はgolang側がgosick-app、redis側がgosick-redis
docker-composeでのサービス名はapp、redisになっています。

ビルド&起動
$ docker-compose up --build -d

各コンテナログイン
$ sh ./scripts/docker_app_run
$ sh ./scripts/docker_redis_run

停止
$ docker-compose stop

停止およびコンテナ削除したい場合はこちら
$ docker-compose down

データ永続化は以下のディレクトリで設定
/docker/construct_redis/data

gosick-appからのredisの接続は以下のコマンドでできます。
//  コンテナログイン
sh ./scripts/docker_app_run
// redis-cli起動
redis-cli -h redis